### PR TITLE
Improve DataMover to Support More Types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,18 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-indago</artifactId>
-		<version>2.2.4</version>
+		<version>2.2.10</version>
 	</parent>
 
 	<properties>

--- a/src/main/java/com/indago/io/DataMover.java
+++ b/src/main/java/com/indago/io/DataMover.java
@@ -165,13 +165,6 @@ public class DataMover {
 	 * @param target
 	 * @throws Exception
 	 */
-//    public static <ST extends NativeType<ST>, TT extends NativeType<TT>> void convertAndCopy(final Img<ST> source, final Img<TT> target) throws Exception {
-//	convertAndCopy( source, Views.iterable(target) );
-//    }
-//
-//    public static <ST extends NativeType<ST>, TT extends NativeType<TT>> void convertAndCopy(final RandomAccessible<ST> source, final RandomAccessibleInterval<TT> target) throws Exception {
-//	convertAndCopy( source, Views.iterable(target) );
-//    }
 
 	@SuppressWarnings( "unchecked" )
 	public static < ST extends RealType< ST >, TT extends NativeType< TT > > void convertAndCopy(
@@ -267,46 +260,7 @@ public class DataMover {
 
 					( ( IntType ) targetCursor.get() ).set( ( ( UnsignedShortType ) sourceRandomAccess.get() ).get() );
 				}
-//			} else
-//			if ( targetType instanceof ARGBType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				int v;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//					try {
-//						v =
-//								Math.round( ( ( UnsignedShortType ) sourceRandomAccess.get() ).getRealFloat() * 255 );
-//					} catch ( final ArrayIndexOutOfBoundsException e ) {
-//						v = 255; // If image-sizes do not match we pad with white pixels...
-//					}
-//					if ( v > 255 ) { throw new Exception( "TODO: in this case (source in not within [0,1]) I did not finish the code!!! Now would likely be a good time... ;)" ); }
-//					( ( ARGBType ) targetCursor.get() ).set( ARGBType.rgba( v, v, v, 255 ) );
-//				}
-//			} else {
-//				throwException = true;
 			}
-//		} else if ( sourceType instanceof ARGBType ) {
-//
-//			// ARGBType --> FloatType
-//			if ( targetType instanceof ARGBType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				double v;
-//				int intRGB;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//					intRGB = ( ( ARGBType ) sourceRandomAccess.get() ).get();
-//					v =
-//							0.2989 * ARGBType.red( intRGB ) + 0.5870 * ARGBType.green( intRGB ) + 0.1140 * ARGBType.blue( intRGB );
-//					v /= 255;
-//					( ( ARGBType ) targetCursor.get() ).set( ARGBType.rgba( v, v, v, 255 ) );
-//				}
-//			} else {
-//				throwException = true;
-//			}
 		} else {
 			throwException = true;
 		}
@@ -314,104 +268,6 @@ public class DataMover {
 		if ( throwException )
 			throw new Exception( "Convertion from " + sourceType.getClass().toString() + " to " + targetType.getClass() + " not implemented!" );
 	}
-//	@SuppressWarnings( "unchecked" )
-//	public static < ST extends NativeType< ST >, TT extends NativeType< TT > > void convertAndCopy(
-//			final RandomAccessible< ST > source,
-//			final IterableInterval< TT > target ) throws Exception {
-//		final ST sourceType = source.randomAccess().get();
-//		final TT targetType = target.firstElement();
-//
-//		// if source and target are of same type -> use copy since convert is not needed...
-//		if ( sourceType.getClass().isInstance( targetType ) ) {
-//			DataMover.copy( source, ( IterableInterval< ST > ) target );
-//		}
-//
-//		// implemented conversion cases follow here...
-//
-//		boolean throwException = false;
-//		if ( sourceType instanceof FloatType ) {
-//
-//			// FloatType --> ARGBType
-//			if ( targetType instanceof ARGBType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				int v;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//					try {
-//						v = Math.round( ( ( FloatType ) sourceRandomAccess.get() ).get() * 255 );
-//					} catch ( final ArrayIndexOutOfBoundsException e ) {
-//						v = 255; // If image-sizes do not match we pad with white pixels...
-//					}
-//					if ( v > 255 ) { throw new Exception( "TODO: in this case (source in not within [0,1]) I did not finish the code!!! Now would likely be a good time... ;)" ); }
-//					( ( ARGBType ) targetCursor.get() ).set( ARGBType.rgba( v, v, v, 255 ) );
-//				}
-//			} else {
-//				throwException = true;
-//			}
-//
-//		} else if ( sourceType instanceof UnsignedShortType ) {
-//
-//			// RealType --> FloatType
-//			if ( targetType instanceof FloatType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				final int v;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//
-//					( ( FloatType ) targetCursor.get() ).set( ( ( UnsignedShortType ) sourceRandomAccess.get() ).getRealFloat() );
-//				}
-//			} else
-//			// RealType --> ARGBType
-//			if ( targetType instanceof ARGBType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				int v;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//					try {
-//						v =
-//								Math.round( ( ( UnsignedShortType ) sourceRandomAccess.get() ).getRealFloat() * 255 );
-//					} catch ( final ArrayIndexOutOfBoundsException e ) {
-//						v = 255; // If image-sizes do not match we pad with white pixels...
-//					}
-//					if ( v > 255 ) { throw new Exception( "TODO: in this case (source in not within [0,1]) I did not finish the code!!! Now would likely be a good time... ;)" ); }
-//					( ( ARGBType ) targetCursor.get() ).set( ARGBType.rgba( v, v, v, 255 ) );
-//				}
-//			} else {
-//				throwException = true;
-//			}
-//		} else if ( sourceType instanceof ARGBType ) {
-//
-//			// ARGBType --> FloatType
-//			if ( targetType instanceof ARGBType ) {
-//				final Cursor< TT > targetCursor = target.localizingCursor();
-//				final RandomAccess< ST > sourceRandomAccess = source.randomAccess();
-//				double v;
-//				int intRGB;
-//				while ( targetCursor.hasNext() ) {
-//					targetCursor.fwd();
-//					sourceRandomAccess.setPosition( targetCursor );
-//					intRGB = ( ( ARGBType ) sourceRandomAccess.get() ).get();
-//					v =
-//							0.2989 * ARGBType.red( intRGB ) + 0.5870 * ARGBType.green( intRGB ) + 0.1140 * ARGBType.blue( intRGB );
-//					v /= 255;
-//					( ( ARGBType ) targetCursor.get() ).set( ARGBType.rgba( v, v, v, 255 ) );
-//				}
-//			} else {
-//				throwException = true;
-//			}
-//		} else {
-//			throwException = true;
-//		}
-//
-//		if ( throwException )
-//			throw new Exception( "Convertion between the given NativeTypes not implemented!" );
-//	}
 
 	public static < T extends RealType< T > & NativeType< T > > Img< T > stackThemAsFrames( final List< Img< T > > imageList )
 			throws ImgIOException, IncompatibleTypeException, Exception {

--- a/src/test/java/com/indago/io/DataMoverBenchmark.java
+++ b/src/test/java/com/indago/io/DataMoverBenchmark.java
@@ -22,17 +22,26 @@ public class DataMoverBenchmark {
 	private final long[] dimensions = {1000, 1000};
 
 	Img<FloatType> floats = ArrayImgs.floats(dimensions);
+	Img<FloatType> floats2 = ArrayImgs.floats(dimensions);
 	Img<DoubleType > doubles = ArrayImgs.doubles(dimensions);
+	Img<DoubleType > doubles2 = ArrayImgs.doubles(dimensions);
 	Img<UnsignedShortType > shorts = ArrayImgs.unsignedShorts(dimensions);
+	Img<UnsignedShortType > shorts2 = ArrayImgs.unsignedShorts(dimensions);
 	Img<IntType > ints = ArrayImgs.ints(dimensions);
 
 	@Benchmark
-	public void testFloatToDouble() throws Exception {
+	public void benchmarkConvertAndCopy() throws Exception {
 		DataMover.convertAndCopy(floats, doubles);
 		DataMover.convertAndCopy(shorts, ints);
 		DataMover.convertAndCopy(shorts, floats);
 	}
 
+	@Benchmark
+	public void benchmarkCopy() {
+		DataMover.copy(floats, floats2);
+		DataMover.copy(doubles, doubles2);
+		DataMover.copy(shorts, shorts2);
+	}
 	public static void main( final String... args ) throws RunnerException
 	{
 		final Options opt = new OptionsBuilder()

--- a/src/test/java/com/indago/io/DataMoverBenchmark.java
+++ b/src/test/java/com/indago/io/DataMoverBenchmark.java
@@ -1,0 +1,48 @@
+package com.indago.io;
+
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State(Scope.Benchmark)
+public class DataMoverBenchmark {
+
+	private final long[] dimensions = {1000, 1000};
+
+	Img<FloatType> floats = ArrayImgs.floats(dimensions);
+	Img<DoubleType > doubles = ArrayImgs.doubles(dimensions);
+	Img<UnsignedShortType > shorts = ArrayImgs.unsignedShorts(dimensions);
+	Img<IntType > ints = ArrayImgs.ints(dimensions);
+
+	@Benchmark
+	public void testFloatToDouble() throws Exception {
+		DataMover.convertAndCopy(floats, doubles);
+		DataMover.convertAndCopy(shorts, ints);
+		DataMover.convertAndCopy(shorts, floats);
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( DataMover.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 20 )
+				.measurementIterations( 20 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/com/indago/io/DataMoverTest.java
+++ b/src/test/java/com/indago/io/DataMoverTest.java
@@ -14,7 +14,6 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -58,7 +57,6 @@ public class DataMoverTest {
 		testConvertAndCopy(new FloatType(42), new DoubleType(42));
 	}
 
-	@Ignore
 	@Test
 	public void testConvertAndCopyIntegerTypeToIntType() {
 		testConvertAndCopy(new ByteType((byte) 42), new IntType(42));
@@ -69,13 +67,11 @@ public class DataMoverTest {
 		testConvertAndCopy(new FloatType(42), new IntType(42));
 	}
 
-	@Ignore
 	@Test
 	public void testConvertAndCopyRealTypeToFloatType() {
 		testConvertAndCopy(new IntType(42), new FloatType(42));
 	}
 
-	@Ignore
 	@Test
 	public void testConvertAndCopyRealTypeToDoubleType() {
 		testConvertAndCopy(new IntType(42), new DoubleType(42));

--- a/src/test/java/com/indago/io/DataMoverTest.java
+++ b/src/test/java/com/indago/io/DataMoverTest.java
@@ -1,0 +1,115 @@
+package com.indago.io;
+
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DataMoverTest {
+
+	@Test
+	public void testCopy() {
+		Img<IntType> in = ArrayImgs.ints(new int[]{42}, 1);
+		Img<IntType> out = ArrayImgs.ints(1);
+		DataMover.copy(in, (RandomAccessibleInterval<IntType>) out);
+		assertEquals(42, out.firstElement().get());
+	}
+
+	@Test
+	public void testCopyWithConverter() {
+		Img<IntType> in = ArrayImgs.ints(new int[]{42}, 1);
+		Img<FloatType> out = ArrayImgs.floats(1);
+		DataMover.copy(in, (IterableInterval<FloatType>) out, (i,o) -> o.set(i.get()));
+		assertEquals(42, out.firstElement().get(), 0.0f);
+	}
+
+	@Test
+	public void testAdd() {
+		Img<IntType> in = ArrayImgs.ints(new int[]{42}, 1);
+		Img<IntType> out = ArrayImgs.ints(new int[]{4}, 1);
+		DataMover.add(in, (RandomAccessibleInterval<IntType>) out);
+		assertEquals(46, out.firstElement().get());
+	}
+
+	@Test
+	public void testConvertAndCopyIntTypeToIntType() {
+		testConvertAndCopy(new IntType(42), new IntType(42));
+	}
+
+	@Test
+	public void testConvertAndCopyFloatTypeToDoubleType() {
+		testConvertAndCopy(new FloatType(42), new DoubleType(42));
+	}
+
+	@Ignore
+	@Test
+	public void testConvertAndCopyIntegerTypeToIntType() {
+		testConvertAndCopy(new ByteType((byte) 42), new IntType(42));
+	}
+
+	@Test
+	public void testConvertAndCopyFloatTypeToIntType() {
+		testConvertAndCopy(new FloatType(42), new IntType(42));
+	}
+
+	@Ignore
+	@Test
+	public void testConvertAndCopyRealTypeToFloatType() {
+		testConvertAndCopy(new IntType(42), new FloatType(42));
+	}
+
+	@Ignore
+	@Test
+	public void testConvertAndCopyRealTypeToDoubleType() {
+		testConvertAndCopy(new IntType(42), new DoubleType(42));
+	}
+
+	@Test
+	public void testConvertAndCopyFloatTypeToARGBType() {
+		testConvertAndCopy(new FloatType(0.5f), new ARGBType(ARGBType.rgba(128, 128, 128, 255)));
+	}
+
+	@Test
+	public void testConvertAndCopyUnsignedShortTypeToFloatType() {
+		testConvertAndCopy(new UnsignedShortType(42), new FloatType(42));
+	}
+
+	@Test
+	public void testConvertAndCopyUnsignedShortTypeToIntType() {
+		testConvertAndCopy(new UnsignedShortType(42), new IntType(42));
+	}
+
+	@Test
+	public void testConvertAndCopyUnsignedShortTypeToDoubleType() {
+		testConvertAndCopy(new UnsignedShortType(42), new DoubleType(42));
+	}
+
+	private <S extends RealType<S>, T extends NativeType<T>> void testConvertAndCopy(S input, T expected) {
+		Img<S> in = new ListImg<>(Collections.singleton(input), 1);
+		Img<T> out = new ArrayImgFactory<>(expected.createVariable()).create(1);
+		try {
+			DataMover.convertAndCopy(in, out);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		assertTrue(expected.valueEquals(out.randomAccess().get()));
+	}
+}


### PR DESCRIPTION
Tr2dSegmentationImportPlugin fails to load segmentations that are save in 8-bit unsigned byte type tif.
This is because DataMover doesn't support the conversion UnsignedByteType to IntType.

